### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,32 @@ You can read more about ViteJS on [vitejs.dev](https://vitejs.dev)
 
 ## Getting started
 
-Install the DDEV add-on and restart the server:
+Install the DDEV add-on:
+
+For DDEV v1.23.5 or above run
+
+```shell
+ddev add-on get wp-strap/ddev-vite
+```
+
+For earlier versions of DDEV run
 
 ```shell
 ddev get wp-strap/ddev-vite
+```
+
+Then restart your project
+
+```shell
 ddev restart
 ```
+
 Or simply bootstrap a new WP project with these combined commands using this add-on: (make sure to change title & URL inside `wp core install` command accordingly)
 
 ```shell
 mkdir wordpress 
 ddev config --docroot=wordpress --project-type=wordpress
-ddev get wp-strap/ddev-vite
+ddev add-on get wp-strap/ddev-vite
 ddev start
 ddev exec wp core download --path="wordpress"
 ddev exec wp core install --path="wordpress" --title="WPVitePlayground" --admin_name="admin" --admin_password="password" --admin_email="admin@local.ddev" --url="https://wp-vite-playground.ddev.site"


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.